### PR TITLE
Add nodata masks for TWS datasets and un-reverse colormap

### DIFF
--- a/datasets/twsanomaly.data.mdx
+++ b/datasets/twsanomaly.data.mdx
@@ -32,7 +32,7 @@ layers:
       layerId: lis-tws-anomaly
       mapLabel: |
         ::js ({ dateFns, datetime, compareDatetime }) => {
-          return `${dateFns.format(datetime, 'yyyy')} VS ${dateFns.format(compareDatetime, 'yyyy')}`;
+          return `${dateFns.format(datetime, 'DD LLL yyyy')} VS ${dateFns.format(compareDatetime, 'DD LLL yyyy')}`;
         }
     legend:
       type: gradient

--- a/datasets/twsanomaly.data.mdx
+++ b/datasets/twsanomaly.data.mdx
@@ -22,10 +22,11 @@ layers:
     sourceParams:
       resampling_method: bilinear
       bidx: 1
-      colormap_name: rdylbu_r
+      colormap_name: rdylbu
       rescale:
         - -200
         - 200
+      nodata: 0
     compare:
       datasetId: tws-anomaly
       layerId: lis-tws-anomaly

--- a/datasets/twsanomaly.data.mdx
+++ b/datasets/twsanomaly.data.mdx
@@ -22,7 +22,7 @@ layers:
     sourceParams:
       resampling_method: bilinear
       bidx: 1
-      colormap_name: rdylbu
+      colormap_name: rdylbu_r
       rescale:
         - -200
         - 200
@@ -40,12 +40,12 @@ layers:
       min: "-200"
       max: "200"
       stops:
-      - "#313695"
-      - "#74add1"
-      - "#e0f3f8"
-      - "#fee090"
-      - "#f46d43"
       - "#a50026"
+      - "#f46d43"
+      - "#fee090"
+      - "#e0f3f8"
+      - "#74add1"
+      - "#313695"
 ---
 <Block>
 <Prose>

--- a/datasets/twstrend.data.mdx
+++ b/datasets/twstrend.data.mdx
@@ -21,7 +21,7 @@ layers:
       - 11
     sourceParams:
       bidx: 1
-      colormap_name: rdylbu
+      colormap_name: rdylbu_r
       rescale:
         - -1
         - 1
@@ -32,12 +32,12 @@ layers:
       min: "-1"
       max: "1"
       stops:
-      - "#313695"
-      - "#74add1"
-      - "#e0f3f8"
-      - "#fee090"
-      - "#f46d43"
       - "#a50026"
+      - "#f46d43"
+      - "#fee090"
+      - "#e0f3f8"
+      - "#74add1"
+      - "#313695"
 ---
 <Block>
 <Prose>

--- a/datasets/twstrend.data.mdx
+++ b/datasets/twstrend.data.mdx
@@ -25,6 +25,7 @@ layers:
       rescale:
         - -1
         - 1
+      nodata: -9999
     legend:
       type: gradient
       label: Trend in TWS Anomaly 


### PR DESCRIPTION
## What
- added nodata values to tws dataset config files
- changed colormap to rdylbu to agree with legend stops

## How tested
Served locally and reviewed on localhost. While the change was minor I ended up needing to rerun the setup to run successfully.
```
git submodule update --init --recursive
./.delta/setup
```