### PR TITLE
Update `nodata` and `rescale` values for EPA emissions

### DIFF
--- a/datasets/epa-agriculture.data.mdx
+++ b/datasets/epa-agriculture.data.mdx
@@ -28,7 +28,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 4642801975296
+      max: 46428019752
       stops:
         - "#60007d"
         - "#30137d"
@@ -54,7 +54,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 4642801975296
+      max: 46428019752
       stops:
         - "#60007d"
         - "#30137d"
@@ -80,7 +80,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 3832787501056
+      max: 38327875010
       stops:
         - "#60007d"
         - "#30137d"
@@ -106,7 +106,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 5481542713344
+      max: 54815427133
       stops:
         - "#60007d"
         - "#30137d"
@@ -160,7 +160,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 80078839808
+      max: 800788398
       stops:
         - "#60007d"
         - "#30137d"
@@ -186,7 +186,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 451068985344
+      max: 4510689853
       stops:
         - "#60007d"
         - "#30137d"

--- a/datasets/epa-agriculture.data.mdx
+++ b/datasets/epa-agriculture.data.mdx
@@ -23,7 +23,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 4642801975296
+        - 46428019752
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -48,11 +49,12 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 13619016237056
+        - 46428019752
+      nodata: 0
     legend:
       type: gradient
       min: 0
-      max: 13619016237056
+      max: 4642801975296
       stops:
         - "#60007d"
         - "#30137d"
@@ -73,7 +75,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 3832787501056
+        - 38327875010
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -98,7 +101,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 5481542713344
+        - 54815427133
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -130,7 +134,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 4544786857984
+      max: 43784598420
       stops:
         - "#60007d"
         - "#30137d"
@@ -151,7 +155,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 80078839808
+        - 800788398
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -176,7 +181,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 451068985344
+        - 4510689853
+      nodata: 0
     legend:
       type: gradient
       min: 0

--- a/datasets/epa-coal-mines.data.mdx
+++ b/datasets/epa-coal-mines.data.mdx
@@ -28,7 +28,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 202263465295872
+      max: 2022634652958
       stops:
         - '#60007d'
         - '#30137d'
@@ -54,7 +54,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 100246608674816
+      max: 1002466086748
       stops:
         - '#60007d'
         - '#30137d'
@@ -80,7 +80,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 9016389402624
+      max: 90163894026
       stops:
         - '#60007d'
         - '#30137d'

--- a/datasets/epa-coal-mines.data.mdx
+++ b/datasets/epa-coal-mines.data.mdx
@@ -23,7 +23,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 202263465295872
+        - 2022634652958
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -48,7 +49,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 100246608674816
+        - 1002466086748
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -73,7 +75,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 9016389402624
+        - 90163894026
+      nodata: 0
     legend:
       type: gradient
       min: 0

--- a/datasets/epa-natural-gas-systems.data.mdx
+++ b/datasets/epa-natural-gas-systems.data.mdx
@@ -28,7 +28,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 96386741698560
+      max: 963867416985
       stops:
         - '#60007d'
         - '#30137d'
@@ -54,7 +54,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 19460020764672
+      max: 194600207646
       stops:
         - '#60007d'
         - '#30137d'
@@ -82,7 +82,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 20158080876544
+      max: 201580808765
       stops:
         - '#60007d'
         - '#30137d'
@@ -108,7 +108,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 13882637680640
+      max: 138826376806
       stops:
         - '#60007d'
         - '#30137d'
@@ -134,7 +134,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 3262177607680
+      max: 32621776076
       stops:
         - '#60007d'
         - '#30137d'

--- a/datasets/epa-natural-gas-systems.data.mdx
+++ b/datasets/epa-natural-gas-systems.data.mdx
@@ -23,7 +23,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 96386741698560
+        - 963867416985
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -48,7 +49,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 19460020764672
+        - 194600207646
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -75,7 +77,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 20158080876544
+        - 201580808765
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -100,7 +103,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 13882637680640
+        - 138826376806
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -125,7 +129,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 3262177607680
+        - 32621776076
+      nodata: 0
     legend:
       type: gradient
       min: 0

--- a/datasets/epa-other.data.mdx
+++ b/datasets/epa-other.data.mdx
@@ -23,7 +23,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 371596820480
+        - 3715968204
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -48,7 +49,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 231657013248
+        - 2316570132
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -75,7 +77,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 112680968192
+        - 1126809681
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -104,7 +107,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 1169998479360
+        - 11699984793
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -133,7 +137,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 1179256356864
+        - 11792563568
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -158,7 +163,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 2303981780992
+        - 23039817809
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -183,7 +189,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 169077309964288
+        - 1690773099642
+      nodata: 0
     legend:
       type: gradient
       min: 0

--- a/datasets/epa-other.data.mdx
+++ b/datasets/epa-other.data.mdx
@@ -28,7 +28,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 371596820480
+      max: 3715968204
       stops:
         - '#60007d'
         - '#30137d'
@@ -54,7 +54,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 231657013248
+      max: 2316570132
       stops:
         - '#60007d'
         - '#30137d'
@@ -82,7 +82,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 112680968192
+      max: 1126809681
       stops:
         - '#60007d'
         - '#30137d'
@@ -112,7 +112,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 1169998479360
+      max: 11699984793
       stops:
         - '#60007d'
         - '#30137d'
@@ -142,7 +142,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 1179256356864
+      max: 11792563568
       stops:
         - '#60007d'
         - '#30137d'
@@ -168,7 +168,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 2303981780992
+      max: 23039817809
       stops:
         - '#60007d'
         - '#30137d'
@@ -194,7 +194,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 169077309964288
+      max: 1690773099642
       stops:
         - '#60007d'
         - '#30137d'

--- a/datasets/epa-petroleum-systems.data.mdx
+++ b/datasets/epa-petroleum-systems.data.mdx
@@ -25,7 +25,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 28220791455744
+        - 282207914557
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -52,7 +53,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 37636576116736
+        - 376365761167
+      nodata: 0
     legend:
       type: gradient
       min: 0

--- a/datasets/epa-petroleum-systems.data.mdx
+++ b/datasets/epa-petroleum-systems.data.mdx
@@ -30,7 +30,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 28220791455744
+      max: 282207914557
       stops:
         - '#60007d'
         - '#30137d'
@@ -58,7 +58,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 37636576116736
+      max: 376365761167
       stops:
         - '#60007d'
         - '#30137d'

--- a/datasets/epa-waste.data.mdx
+++ b/datasets/epa-waste.data.mdx
@@ -23,7 +23,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 9190181437440
+        - 91901814374
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -50,7 +51,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 128375163191296
+        - 1283751631912
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -77,7 +79,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 24977663328256
+        - 249776633282
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -104,7 +107,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 67544639602688
+        - 675446396026
+      nodata: 0
     legend:
       type: gradient
       min: 0
@@ -129,7 +133,8 @@ layers:
       colormap_name: rainbow
       rescale:
         - 0
-        - 771822452736
+        - 7718224527
+      nodata: 0
     legend:
       type: gradient
       min: 0

--- a/datasets/epa-waste.data.mdx
+++ b/datasets/epa-waste.data.mdx
@@ -112,7 +112,7 @@ layers:
     legend:
       type: gradient
       min: 0
-      max: 67544639602688
+      max: 675446396026
       stops:
         - '#60007d'
         - '#30137d'


### PR DESCRIPTION
# Changes
- Updated nodata and rescale values for all of the EPA datasets to make the visualization look nicer
- Update the legends to match the previous update

An example viz:
![image](https://user-images.githubusercontent.com/7830949/190500631-543ded0b-c0f2-4741-b0ab-c984663b3bd5.png)
